### PR TITLE
Want to have a tabs spaces conversion tool which calculate tab-stops properly

### DIFF
--- a/src/whitespacer.ts
+++ b/src/whitespacer.ts
@@ -30,7 +30,7 @@ export class Whitespacer {
                 } else if ((c >= 0x2000 && c <= 0xFF60) || (c >= 0xFFA0)) {
                     width += 2; // full-width char
                 } else {
-                    width += 0; // zero-width char
+                    width += 0; // treat 0x00 to 0x1F control char (except tab) as zero-width
                 }
             }
             let numTabs = x.length - i;

--- a/src/whitespacer.ts
+++ b/src/whitespacer.ts
@@ -12,9 +12,31 @@ export class Whitespacer {
      * @return {string} new text after replaced to spaces
      */
     public convertTabsToSpaces(tabSize: number, text: string): string {
-        // use + 1 to add last space
+        /* // use + 1 to add last space
         var spaces = new Array(tabSize + 1).join(' ');
-        var newText = text.replace(/\t/g, spaces);
+        var newText = text.replace(/\t/g, spaces); */
+
+        // convert tabs to the right tabstops property
+        var newText = text.replace(/[^\r\n\t]*\t+/g, function (x) {
+            let width = 0; // characters total width before tab
+            let i = 0;
+            for (; ; ++i) {
+                let c = x.charCodeAt(i);
+                if (c == 0x09) // tab char
+                    break;
+                // simplified way of checking character width
+                if ((c >= 0x0020 && c <= 0x1FFF) || (c >= 0xFF61 && c <= 0xFF9F)) {
+                    width += 1;
+                } else if ((c >= 0x2000 && c <= 0xFF60) || (c >= 0xFFA0)) {
+                    width += 2; // full-width char
+                } else {
+                    width += 0; // zero-width char
+                }
+            }
+            let numTabs = x.length - i;
+            let totalTabSize = tabSize * numTabs - (width % tabSize);
+            return x.substr(0, i) + " ".repeat(totalTabSize);
+        });
 
         return newText;
     }
@@ -27,9 +49,15 @@ export class Whitespacer {
      * @return {string} new text after replaced to tabs
      */
     public convertSpacesToTabs(tabSize: number, text: string): string {
-        // use + 1 to add last space
+        /* // use + 1 to add last space
         var spaces = new Array(tabSize + 1).join(' ');
-        var newText = text.replace(new RegExp(spaces, 'g'), '\t');
+        var newText = text.replace(new RegExp(spaces, 'g'), '\t'); */
+
+        // Only convert leading whitespaces for simplicity.  It is difficult to convert inline spaces to the right tabstop with regular expression.
+        var regex2 = new RegExp("[ ]{" + tabSize + "}|[ ]{0," + (tabSize - 1) + "}\t", 'g');
+        var newText = text.replace(new RegExp("^([ ]{" + tabSize + "}|[ ]{0," + (tabSize - 1) + "}\t)*", 'mg'), function (x) {
+            return x.replace(regex2, '\t');
+        });
 
         return newText;
     }

--- a/src/whitespacer.ts
+++ b/src/whitespacer.ts
@@ -53,11 +53,20 @@ export class Whitespacer {
         var spaces = new Array(tabSize + 1).join(' ');
         var newText = text.replace(new RegExp(spaces, 'g'), '\t'); */
 
-        // Only convert leading whitespaces for simplicity.  It is difficult to convert inline spaces to the right tabstop with regular expression.
+        // convert spaces to tabs with proper tabstops, not only at leading indentation (limitation: not support full-width unicode characters)
+        var regex1 = new RegExp(" {2,}$");
         var regex2 = new RegExp("[ ]{" + tabSize + "}|[ ]{0," + (tabSize - 1) + "}\t", 'g');
-        var newText = text.replace(new RegExp("^([ ]{" + tabSize + "}|[ ]{0," + (tabSize - 1) + "}\t)*", 'mg'), function (x) {
-            return x.replace(regex2, '\t');
-        });
+        var newText = text.replace(new RegExp("([^ \r\n\t]{" + (tabSize - 1) + "}[^\r\n\t])?" // 4th char not space, if any
+                + "((?:[^ \r\n\t]{" + tabSize + "})*)"                                        // multiple groups of 4 not spaces, if any
+                + "([^\r\n\t]{" + tabSize + "})"                                              // 4 char space or not
+                + "((?:[ ]{" + tabSize + "}|[ ]{0," + (tabSize - 1) + "}\t)*)", 'gm'),        // group of spaces, or space + tab, if any
+            function (_, g1, g2, g3, g4) {
+                if (g3 && g3.endsWith('  ')) {
+                    g3 = g3.replace(regex1, '\t');
+                }
+                return (g1 || '') + (g2 || '') + (g3 || '') + (g4 || '').replace(regex2, '\t');
+            }
+        );
 
         return newText;
     }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -8,23 +8,23 @@ suite('Extension Tests', () => {
     test('Whitespacer: Convert tabs to spaces', () => {
         let whitespacer = new Whitespacer();
 
-        var inputText = '\ta\n\t\nb\t\nc\t\td\n \te';
+        var inputText = '\ta\n\t\nb\t\nc\t\td\n \t\te全\tf\0\t'; // width of \0 is zero.  "全" is a full-width (width=2) char
         var tabSize = 2;
         var newText = whitespacer.convertTabsToSpaces(tabSize, inputText);
-        assert.equal(newText, '  a\n  \nb  \nc    d\n  e');
+        assert.equal(newText, '  a\n  \nb \nc   d\n    e全 f\0 ');
 
         tabSize = 3;
         newText = whitespacer.convertTabsToSpaces(tabSize, inputText);
-        assert.equal(newText, '   a\n   \nb   \nc      d\n   e');
+        assert.equal(newText, '   a\n   \nb  \nc     d\n      e全   f\0  ');
     });
 
     test('Whitespacer: Convert spaces to tabs', () => {
         let whitespacer = new Whitespacer();
 
-        let inputText = '  a\n  \nb  \nc    d\n   e';
+        let inputText = '  a\n  \nb  \nc    d\n     ee    f   ';
         let tabSize = 2;
         let newText = whitespacer.convertSpacesToTabs(tabSize, inputText);
 
-        assert.equal(newText, '\ta\n\t\nb\t\nc\t\td\n\t e');
+        assert.equal(newText, '\ta\n\t\nb  \nc \t d\n\t\t ee \t f\t ');
     });
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -2,29 +2,29 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as myExtension from '../src/extension';
-import {Whitespacer} from '../src/whitespacer';
+import { Whitespacer } from '../src/whitespacer';
 
 suite('Extension Tests', () => {
-	test('Whitespacer: Convert tabs to spaces', () => {
-		let whitespacer = new Whitespacer();
+    test('Whitespacer: Convert tabs to spaces', () => {
+        let whitespacer = new Whitespacer();
 
-        var inputText = '\ta\n\t\nb\t\nc\t\td';
+        var inputText = '\ta\n\t\nb\t\nc\t\td\n \te';
         var tabSize = 2;
         var newText = whitespacer.convertTabsToSpaces(tabSize, inputText);
-        assert.equal(newText, '  a\n  \nb  \nc    d');
+        assert.equal(newText, '  a\n  \nb  \nc    d\n  e');
 
         tabSize = 3;
         newText = whitespacer.convertTabsToSpaces(tabSize, inputText);
-        assert.equal(newText, '   a\n   \nb   \nc      d');
-	});
+        assert.equal(newText, '   a\n   \nb   \nc      d\n   e');
+    });
 
     test('Whitespacer: Convert spaces to tabs', () => {
-		let whitespacer = new Whitespacer();
+        let whitespacer = new Whitespacer();
 
-        let inputText = '  a\n  \nb  \nc    d';
+        let inputText = '  a\n  \nb  \nc    d\n   e';
         let tabSize = 2;
         let newText = whitespacer.convertSpacesToTabs(tabSize, inputText);
 
-        assert.equal(newText, '\ta\n\t\nb\t\nc\t\td');
-	});
+        assert.equal(newText, '\ta\n\t\nb\t\nc\t\td\n\t e');
+    });
 });


### PR DESCRIPTION
Dear developer,

  I'm looking for a plugin in vscode to convert tabs to spaces.  However, many only substitute a tab to 4 spaces without variable tab-stops consideration.  As editor almost always use tabstops to align tab char width, replacing to constant # of spaces is improper and give different output alignment for inline tabs (i.e. non-leading ones).

  I found your plugin compact and easy to use, but the logic is not quite right, thus I edit tab-stops logic based on it.

  Would you like to merge this logic which I think is proper?  (may be optionally call Whitespacer2 as logic totally different)

  Otherwise, I may need to try to submit a new plugin for my logic.

  (Note: vscode already have commands to converts only leading indentation to tabs or spaces in latest version.  This plugin's command serve different purpose)

  Thank you.

Best Regards,
  Johnny Wong.